### PR TITLE
Change error callback type to `ErrorType`

### DIFF
--- a/CBGPromise/Future.swift
+++ b/CBGPromise/Future.swift
@@ -2,10 +2,10 @@ import Foundation
 
 public class Future<T> {
     var successCallback: ((T) -> ())?
-    var errorCallback: ((NSError) -> ())?
+    var errorCallback: ((ErrorType) -> ())?
 
     public var value: T?
-    public var error: NSError?
+    public var error: ErrorType?
 
     let semaphore: dispatch_semaphore_t
 
@@ -21,7 +21,7 @@ public class Future<T> {
         }
     }
 
-    public func error(callback: (NSError) -> ()) {
+    public func error(callback: (ErrorType) -> ()) {
         errorCallback = callback
 
         if let error = error {
@@ -43,7 +43,7 @@ public class Future<T> {
         dispatch_semaphore_signal(semaphore)
     }
 
-    func reject(error: NSError) {
+    func reject(error: ErrorType) {
         self.error = error
 
         if let errorCallback = errorCallback {

--- a/CBGPromise/Promise.swift
+++ b/CBGPromise/Promise.swift
@@ -11,7 +11,7 @@ public class Promise<T> {
         future.resolve(value)
     }
 
-    public func reject(error: NSError) {
+    public func reject(error: ErrorType) {
         future.reject(error)
     }
 }

--- a/CBGPromiseTests/PromiseSpec.swift
+++ b/CBGPromiseTests/PromiseSpec.swift
@@ -13,7 +13,7 @@ class PromiseSpec: QuickSpec {
 
             describe("calling the callback blocks") {
                 var value: String?
-                var error: NSError?
+                var error: ErrorType?
 
                 beforeEach {
                     value = nil


### PR DESCRIPTION
This allows us to use the more generic ErrorType when rejecting
promises. This is advantageous, as it allows the error callback to
subsequently `throw` a pure `ErrorType` without it having to be an
`NSError` object.

Signed-off-by: Mike Stallard mstallard@pivotal.io
