### PR TITLE
Make error type generic

### DIFF
--- a/CBGPromise/Future.swift
+++ b/CBGPromise/Future.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public class Future<T> {
+public class Future<T, ET> {
     var successCallbacks: [(T) -> ()]
-    var errorCallbacks: [(ErrorType) -> ()]
+    var errorCallbacks: [(ET) -> ()]
 
     public var value: T?
-    public var error: ErrorType?
+    public var error: ET?
 
     let semaphore: dispatch_semaphore_t
 
@@ -15,7 +15,7 @@ public class Future<T> {
         errorCallbacks = []
     }
 
-    public func then(callback: (T) -> ()) -> Future<T> {
+    public func then(callback: (T) -> ()) -> Future<T, ET> {
         successCallbacks.append(callback)
 
         if let value = value {
@@ -25,7 +25,7 @@ public class Future<T> {
         return self
     }
 
-    public func error(callback: (ErrorType) -> ()) -> Future<T> {
+    public func error(callback: (ET) -> ()) -> Future<T, ET> {
         errorCallbacks.append(callback)
 
         if let error = error {
@@ -49,7 +49,7 @@ public class Future<T> {
         dispatch_semaphore_signal(semaphore)
     }
 
-    func reject(error: ErrorType) {
+    func reject(error: ET) {
         self.error = error
 
         for errorCallback in errorCallbacks {

--- a/CBGPromise/Future.swift
+++ b/CBGPromise/Future.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class Future<T, ET> {
+public class Future<T, ET: ErrorType> {
     var successCallbacks: [(T) -> ()]
     var errorCallbacks: [(ET) -> ()]
 

--- a/CBGPromise/Promise.swift
+++ b/CBGPromise/Promise.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class Promise<T, ET> {
+public class Promise<T, ET: ErrorType> {
     public let future: Future<T, ET>
 
     public init() {

--- a/CBGPromise/Promise.swift
+++ b/CBGPromise/Promise.swift
@@ -1,17 +1,17 @@
 import Foundation
 
-public class Promise<T> {
-    public let future: Future<T>
+public class Promise<T, ET> {
+    public let future: Future<T, ET>
 
     public init() {
-        future = Future<T>()
+        future = Future<T, ET>()
     }
 
     public func resolve(value: T) {
         future.resolve(value)
     }
 
-    public func reject(error: ErrorType) {
+    public func reject(error: ET) {
         future.reject(error)
     }
 }

--- a/CBGPromiseTests/PromiseSpec.swift
+++ b/CBGPromiseTests/PromiseSpec.swift
@@ -5,15 +5,15 @@ import CBGPromise
 class PromiseSpec: QuickSpec {
     override func spec() {
         describe("Promise") {
-            var subject: Promise<String>!
+            var subject: Promise<String, NSError>!
 
             beforeEach {
-                subject = Promise<String>()
+                subject = Promise<String, NSError>()
             }
 
             describe("calling the callback blocks") {
                 var value: String?
-                var error: ErrorType?
+                var error: NSError?
 
                 beforeEach {
                     value = nil


### PR DESCRIPTION
Just kidding! :D If we make the error type generic and declared as part
of the type of the Promise/Future, that means that we can rewrite code
like this:

``` swift
switch future.error as! SomeClass.Error {
case SomeClass.Error.Type(let underlyingError):
    expect(underlyingError).to(beIdenticalTo(originalError))
default:
    fail("wrong error found")
}
```

As:

``` swift
switch future.error {
case SomeClass.Error.Type(let underlyingError):
    expect(underlyingError).to(beIdenticalTo(originalError))
default:
    fail("wrong error found")
}
```

Signed-off-by: Mike Stallard mstallard@pivotal.io
