### PR TITLE
Callback chaining

### DIFF
--- a/CBGPromise/Future.swift
+++ b/CBGPromise/Future.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public class Future<T> {
-    var successCallback: ((T) -> ())?
-    var errorCallback: ((ErrorType) -> ())?
+    var successCallbacks: [(T) -> ()]
+    var errorCallbacks: [(ErrorType) -> ()]
 
     public var value: T?
     public var error: ErrorType?
@@ -11,10 +11,12 @@ public class Future<T> {
 
     init() {
         semaphore = dispatch_semaphore_create(0)
+        successCallbacks = []
+        errorCallbacks = []
     }
 
     public func then(callback: (T) -> ()) {
-        successCallback = callback
+        successCallbacks.append(callback)
 
         if let value = value {
             callback(value)
@@ -22,7 +24,7 @@ public class Future<T> {
     }
 
     public func error(callback: (ErrorType) -> ()) {
-        errorCallback = callback
+        errorCallbacks.append(callback)
 
         if let error = error {
             callback(error)
@@ -36,7 +38,7 @@ public class Future<T> {
     func resolve(value: T) {
         self.value = value
 
-        if let successCallback = successCallback {
+        for successCallback in successCallbacks {
             successCallback(value)
         }
 
@@ -46,7 +48,7 @@ public class Future<T> {
     func reject(error: ErrorType) {
         self.error = error
 
-        if let errorCallback = errorCallback {
+        for errorCallback in errorCallbacks {
             errorCallback(error)
         }
 

--- a/CBGPromise/Future.swift
+++ b/CBGPromise/Future.swift
@@ -15,20 +15,24 @@ public class Future<T> {
         errorCallbacks = []
     }
 
-    public func then(callback: (T) -> ()) {
+    public func then(callback: (T) -> ()) -> Future<T> {
         successCallbacks.append(callback)
 
         if let value = value {
             callback(value)
         }
+        
+        return self
     }
 
-    public func error(callback: (ErrorType) -> ()) {
+    public func error(callback: (ErrorType) -> ()) -> Future<T> {
         errorCallbacks.append(callback)
 
         if let error = error {
             callback(error)
         }
+
+        return self
     }
 
     public func wait() {

--- a/CBGPromiseTests/PromiseSpec.swift
+++ b/CBGPromiseTests/PromiseSpec.swift
@@ -141,6 +141,44 @@ class PromiseSpec: QuickSpec {
                     expect(errorB).to(equal(expectedError))
                 }
             }
+
+            describe("chaining callbacks") {
+                it("can start with the .then") {
+                    let future = subject.future.then { _ in }
+                    
+                    expect(future).to(beIdenticalTo(subject.future))
+                }
+                
+                it("can start with the .error") {
+                    let future = subject.future.error { _ in }
+                    
+                    expect(future).to(beIdenticalTo(subject.future))
+                }
+                
+                describe("when both callbacks are registered") {
+                    var value: String?
+                    var error: ErrorType?
+                    
+                    beforeEach {
+                        subject.future
+                            .then { v in value = v }
+                            .error { e in error = e }
+                    }
+                    
+                    it("calls the success callback when the promise is resolved") {
+                        subject.resolve("My Special Value")
+                        
+                        expect(value).to(equal("My Special Value"))
+                    }
+                    
+                    it("calls the error callback when the promise is rejected") {
+                        let expectedError = NSError(domain: "My Special Domain", code: 123, userInfo: nil)
+                        subject.reject(expectedError)
+                        
+                        expect(error).to(equal(expectedError))
+                    }
+                }
+            }
         }
     }
 }

--- a/CBGPromiseTests/PromiseSpec.swift
+++ b/CBGPromiseTests/PromiseSpec.swift
@@ -112,6 +112,35 @@ class PromiseSpec: QuickSpec {
                     expect(subject.future.error).to(equal(expectedError))
                 }
             }
+            
+            describe("multiple callbacks") {
+                it("calls each callback when the promise is resolved") {
+                    var valA: String?
+                    var valB: String?
+
+                    subject.future.then { v in valA = v }
+                    subject.future.then { v in valB = v }
+                    
+                    subject.resolve("My Special Value")
+                    
+                    expect(valA).to(equal("My Special Value"))
+                    expect(valB).to(equal("My Special Value"))
+                }
+                
+                it("calls each callback when the promise is rejected") {
+                    var errorA: ErrorType?
+                    var errorB: ErrorType?
+                    
+                    subject.future.error { e in errorA = e }
+                    subject.future.error { e in errorB = e }
+                    
+                    let expectedError = NSError(domain: "My Special Domain", code: 123, userInfo: nil)
+                    subject.reject(expectedError)
+                    
+                    expect(errorA).to(equal(expectedError))
+                    expect(errorB).to(equal(expectedError))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This adds the ability to chain callbacks like so:

``` swift
promise.then { value in
  // do something with the value
}.error { error in
  // do something with the error
}
```

This also includes the ability to register multiple callbacks of each type.
