### PR TITLE
ignore subsequent calls to -resolve / -reject

### DIFF
--- a/CBGPromise/Future.swift
+++ b/CBGPromise/Future.swift
@@ -4,6 +4,8 @@ public class Future<T, ET: ErrorType> {
     var successCallbacks: [(T) -> ()]
     var errorCallbacks: [(ET) -> ()]
 
+    private var completed: Bool
+
     public var value: T?
     public var error: ET?
 
@@ -13,6 +15,7 @@ public class Future<T, ET: ErrorType> {
         semaphore = dispatch_semaphore_create(0)
         successCallbacks = []
         errorCallbacks = []
+        completed = false
     }
 
     public func then(callback: (T) -> ()) -> Future<T, ET> {
@@ -40,6 +43,9 @@ public class Future<T, ET: ErrorType> {
     }
 
     func resolve(value: T) {
+        guard !completed else { return }
+
+        self.complete()
         self.value = value
 
         for successCallback in successCallbacks {
@@ -50,6 +56,9 @@ public class Future<T, ET: ErrorType> {
     }
 
     func reject(error: ET) {
+        guard !completed else { return }
+
+        self.complete()
         self.error = error
 
         for errorCallback in errorCallbacks {
@@ -57,5 +66,9 @@ public class Future<T, ET: ErrorType> {
         }
 
         dispatch_semaphore_signal(semaphore)
+    }
+
+    private func complete() {
+        self.completed = true
     }
 }

--- a/CBGPromise/Future.swift
+++ b/CBGPromise/Future.swift
@@ -43,7 +43,7 @@ public class Future<T, ET: ErrorType> {
     }
 
     func resolve(value: T) {
-        guard !completed else { return }
+        guard !completed else { preconditionFailed("resolve"); return }
 
         self.complete()
         self.value = value
@@ -56,7 +56,7 @@ public class Future<T, ET: ErrorType> {
     }
 
     func reject(error: ET) {
-        guard !completed else { return }
+        guard !completed else { preconditionFailed("reject"); return }
 
         self.complete()
         self.error = error
@@ -70,5 +70,9 @@ public class Future<T, ET: ErrorType> {
 
     private func complete() {
         self.completed = true
+    }
+    
+    private func preconditionFailed(call: String) {
+        NSException(name: "invalid \(call)", reason: "already resolved / rejected", userInfo: nil).raise()
     }
 }

--- a/CBGPromiseTests/PromiseSpec.swift
+++ b/CBGPromiseTests/PromiseSpec.swift
@@ -179,6 +179,59 @@ class PromiseSpec: QuickSpec {
                     }
                 }
             }
+
+            describe("multiple resolving / rejecting") {
+                context("resolving after having been resolved already") {
+                    beforeEach {
+                        subject.resolve("old")
+                    }
+
+                    it("does not resolve again") {
+                        subject.resolve("new")
+
+                        expect(subject.future.value).to(equal("old"))
+                    }
+                }
+
+                context("resolving after having been rejected already") {
+                    beforeEach {
+                        subject.reject(NSError(domain: "My Special Domain", code: 123, userInfo: nil))
+                    }
+
+                    it("does not resolve") {
+                        subject.resolve("new")
+
+                        expect(subject.future.value).to(beNil())
+                    }
+                }
+
+                context("rejecting after having been resolved already") {
+                    beforeEach {
+                        subject.resolve("old")
+                    }
+
+                    it("does not reject") {
+                        subject.reject(NSError(domain: "My Special Domain", code: 123, userInfo: nil))
+
+                        expect(subject.future.error).to(beNil())
+                    }
+                }
+
+                context("rejecting after having been rejected already") {
+                    var expectedError: NSError!
+
+                    beforeEach {
+                        expectedError = NSError(domain: "My Special Domain", code: 123, userInfo: nil)
+                        subject.reject(expectedError)
+                    }
+
+                    it("does not reject again") {
+                        subject.reject(NSError(domain: "My New Domain", code: 124, userInfo: nil))
+
+                        expect(subject.future.error).to(equal(expectedError))
+                    }
+                }
+            }
         }
     }
 }

--- a/CBGPromiseTests/PromiseSpec.swift
+++ b/CBGPromiseTests/PromiseSpec.swift
@@ -186,10 +186,8 @@ class PromiseSpec: QuickSpec {
                         subject.resolve("old")
                     }
 
-                    it("does not resolve again") {
-                        subject.resolve("new")
-
-                        expect(subject.future.value).to(equal("old"))
+                    it("raises an exception") {
+                        expect { subject.resolve("new") }.to(raiseException())
                     }
                 }
 
@@ -198,10 +196,8 @@ class PromiseSpec: QuickSpec {
                         subject.reject(NSError(domain: "My Special Domain", code: 123, userInfo: nil))
                     }
 
-                    it("does not resolve") {
-                        subject.resolve("new")
-
-                        expect(subject.future.value).to(beNil())
+                    it("raises an exception") {
+                        expect { subject.resolve("new") }.to(raiseException())
                     }
                 }
 
@@ -210,25 +206,22 @@ class PromiseSpec: QuickSpec {
                         subject.resolve("old")
                     }
 
-                    it("does not reject") {
-                        subject.reject(NSError(domain: "My Special Domain", code: 123, userInfo: nil))
-
-                        expect(subject.future.error).to(beNil())
+                    it("raises an exception") {
+                        expect {
+                            subject.reject(NSError(domain: "My Special Domain", code: 123, userInfo: nil))
+                        }.to(raiseException())
                     }
                 }
 
                 context("rejecting after having been rejected already") {
-                    var expectedError: NSError!
-
                     beforeEach {
-                        expectedError = NSError(domain: "My Special Domain", code: 123, userInfo: nil)
-                        subject.reject(expectedError)
+                        subject.reject(NSError(domain: "My Special Domain", code: 123, userInfo: nil))
                     }
 
-                    it("does not reject again") {
-                        subject.reject(NSError(domain: "My New Domain", code: 124, userInfo: nil))
-
-                        expect(subject.future.error).to(equal(expectedError))
+                    it("raises an exception") {
+                        expect {
+                            subject.reject(NSError(domain: "My Special Domain", code: 123, userInfo: nil))
+                        }.to(raiseException())
                     }
                 }
             }


### PR DESCRIPTION
Before, subsequent calls to resolve / reject would override any prior call. This especially allowed a promise to be resolved _and_ rejected at the same time, leading to unexpected behavior.

Now, any subsequent call to those methods will be silently ignored.

Also, hey @cbguder I'm back at Pivotal ;)
