### PR TITLE
Remove seperate code paths for error handling

### DIFF
--- a/CBGPromise/Promise.swift
+++ b/CBGPromise/Promise.swift
@@ -1,17 +1,13 @@
 import Foundation
 
-public class Promise<T, ET: ErrorType> {
-    public let future: Future<T, ET>
+public class Promise<T> {
+    public let future: Future<T>
 
     public init() {
-        future = Future<T, ET>()
+        future = Future<T>()
     }
 
     public func resolve(value: T) {
         future.resolve(value)
-    }
-
-    public func reject(error: ET) {
-        future.reject(error)
     }
 }


### PR DESCRIPTION
The idea is that promises deal with async behavior only, and the
handling of success and failure should be moved in to a result type by
the client of the promise.

Signed-off-by: Mike Stallard mstallard@pivotal.io

---

Wait, I can request for a pull request to be made from a repository I don't own? This is awesome.
