### PR TITLE
future.wait() returns the future's value

### DIFF
--- a/CBGPromise/Future.swift
+++ b/CBGPromise/Future.swift
@@ -25,8 +25,9 @@ public class Future<T> {
         return self
     }
 
-    public func wait() {
-        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    public func wait() -> T? {
+        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
+        return self.value
     }
 
     public func map<U>(transform: T -> U) -> Future<U> {

--- a/CBGPromiseTests/PromiseSpec.swift
+++ b/CBGPromiseTests/PromiseSpec.swift
@@ -57,9 +57,10 @@ class PromiseSpec: QuickSpec {
                         subject.resolve("My Special Value")
                     }
 
-                    subject.future.wait()
+                    let receivedValue = subject.future.wait()
 
                     expect(subject.future.value).to(equal("My Special Value"))
+                    expect(receivedValue).to(equal(subject.future.value))
                 }
             }
 


### PR DESCRIPTION
This allows a future to be used as `let myValue = future.wait()`
