### PR TITLE
Add a public initializer to future so that I can init a pre-resolved future

### DIFF
--- a/Sources/Future.swift
+++ b/Sources/Future.swift
@@ -16,6 +16,12 @@ public final class Future<T> {
         completed = false
     }
 
+    public convenience init(resolved: T) {
+        self.init()
+
+        self.resolve(resolved)
+    }
+
     @discardableResult
     public func then(callback: @escaping (T) -> Void) -> Future<T> {
         callbacks.append(callback)

--- a/Tests/CBGPromiseTests/PromiseTests.swift
+++ b/Tests/CBGPromiseTests/PromiseTests.swift
@@ -160,5 +160,13 @@ class PromiseTests: QuickSpec {
                 }
             }
         }
+
+        describe("Future") {
+            it("can be init'd with a resolved value") {
+                let future = Future(resolved: "Hello")
+
+                expect(future.value).to(equal("Hello"))
+            }
+        }
     }
 }


### PR DESCRIPTION
So that I can have code that looks like:

`func foo() -> Future<String> { return Future(resolved: "Hello world!") }`

I also thought of adding this to Promise, either as an initializer or a
class func, but didn't because of brevity of using code.

E.G.:

Promise.init(resolved:)

`func foo() -> Future<String> { return Promise(resolved: "Hello world!").future }`

class func:

`func foo() -> Future<String> { return Promise<String>.resolved("Hello world!") }`

The class func would be preferred, but the current swift type system is
unable to infer `T` for this case. (Swift 3.1/Xcode 8.3.1)

Thus, for sake of brevity and such, it's a public initializer on Future.

Note that this is most useful for cases of a .map, with code that looks like, where I want one branch to return a future, but another to return a pre-computed value:

```
func foo() -> Future<String> {
    return someFuture().map { value -> Future<String> in
        if value == "dunno" { return someOtherFuture() }
        else { return Future(resolved: "hello") }
    }
}
```

This is currently resolved by doing something like:
```
let promise = Promise<String>()
promise.resolve("hello")
return promise.future
```

Which is undesirable.